### PR TITLE
Fix statement_en.html.tpl level4

### DIFF
--- a/config/statement_en.html.tpl
+++ b/config/statement_en.html.tpl
@@ -538,7 +538,7 @@ Note: when calculating how many ants to dispatch to a beacon, the result will be
 			<!-- BEGIN level1 -->
 			which equals <const>1</const> for this league.<br>
 			<!-- END -->
-			<!-- BEGIN level2 level3 level 4 -->
+			<!-- BEGIN level2 level3 level4 -->
 			containing the number of bases for each player.<br>
 			<!-- END -->
 			<span class="statement-lineno">Next line:</span> <var>numberOfBases</var> integers for the cell indices


### PR DESCRIPTION
This is a guess, but I believe that this extra white space is causing a bug in the English statement in Silver league.

![image](https://github.com/CodinGame/SpringChallenge2023/assets/1969355/1f63f6ea-80df-495a-a14d-e8db5ec92da0)
